### PR TITLE
Error event gets passed http status as opposed to response body in event of http error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 target/
 .env
+.idea

--- a/src/poller.js
+++ b/src/poller.js
@@ -65,7 +65,7 @@ Poller.prototype.fetch = function () {
 			if (response.status === 200) {
 				self.emit('ok', response, latency);
 			} else {
-				throw response.body;
+				throw new Error(response.status + ' ' + response.statusText);
 			}
 			if ((response.headers.get('content-type') || '').indexOf('json') > -1) {
 				return response.json();


### PR DESCRIPTION
Is this acceptable or is there some important use case here I haven't considered? It would have made my afternoon a bit easier.