### PR TITLE
Fix bug with events and retries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 .editorconfig
 .eslintrc.js
+
+.idea/

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
   node:
-    version: 4.1.1
+    version: 4.5.0

--- a/src/client.js
+++ b/src/client.js
@@ -1,17 +1,23 @@
 /*global CustomElement */
 'use strict';
+class EventEmitter {
 
-var Poller = require('./poller');
+	constructor(){
+		this.el = document.body;
+	}
+
+	emit(eventName, data){
+		this.el.dispatchEvent(new CustomElement(eventName, { detail: data }));
+	}
+
+	on(eventName, fn){
+		this.el.addEventListener(eventName, fn, true);
+	}
+}
+
+const Poller = require('./poller')(EventEmitter);
+
 // eager fetch not yet supported on client side
 Poller.prototype.eagerFetch = fetch;
-var el = document.body;
-
-Poller.prototype.emit = function (eventName, data) {
-		el.dispatchEvent(new CustomElement(eventName, { detail: data }));
-};
-
-Poller.prototype.on = function (eventName, fn) {
-		el.addEventListener(eventName, fn, true);
-};
 
 module.exports = Poller;

--- a/src/poller.js
+++ b/src/poller.js
@@ -1,103 +1,106 @@
 'use strict';
-
 require('isomorphic-fetch');
 
-var Poller = function(config) {
-	if (!config.url) {
-		throw 'ft-poller expects a url';
-	}
 
-	this.url = config.url;
-	this.options = config.options || {};
-	this.data = config.defaultData;
-	this.options.timeout = this.options.timeout || 4000;
+module.exports = EventEmitter => {
 
-	this.options.headers = this.options.headers || {};
+	return class Poller extends EventEmitter {
 
-	this._fetch = this.options.retry ? this.eagerFetch : fetch;
-
-	if (!this.options.headers['Content-Type']) {
-		this.options.headers['Content-Type'] = 'application/json';
-	}
-	if (!this.options.headers.Accept) {
-		this.options.headers['Accept'] = 'application/json';
-	}
-
-	this.refreshInterval = config.refreshInterval || 60000;
-	this.parseData = config.parseData || function (data) {
-		return data;
-	};
-	this.poller = undefined;
-	if (config.autostart) {
-		this.start({initialRequest: true})
-	}
-};
-
-Poller.prototype.isRunning = function () {
-	return !!this.poller;
-};
-
-Poller.prototype.stop = function() {
-	clearInterval(this.poller);
-	this.poller = undefined;
-	return true;
-};
-
-Poller.prototype.start = function (opts) {
-	opts = opts || {};
-	let initialPromise;
-	if (!!this.isRunning()) {
-		throw new Error('Could not start job because the service is already running');
-	}
-
-	if (opts.initialRequest) {
-		initialPromise = this.fetch();
-	}
-
-	var self = this;
-	this.poller = setInterval(function () {
-		self.fetch();
-	}, this.refreshInterval);
-
-	return opts.initialRequest ? initialPromise : Promise.resolve();
-};
-
-Poller.prototype.retry = function(){
-	this.fetch();
-	clearInterval(this.poller);
-	this.poller = setInterval( () => {
-		this.fetch();
-	}, this.refreshInterval);
-};
-
-Poller.prototype.fetch = function () {
-	var time = new Date();
-	var self = this;
-	return this._fetch(this.url, this.options)
-		.then(function (response) {
-			var latency = new Date() - time;
-			if (response.status === 200) {
-				self.emit('ok', response, latency);
-			} else {
-				throw `Fetching ${response.url} failed with a ${response.status}, ${response.statusText}`;
+		constructor(config){
+			super();
+			if (!config.url) {
+				throw 'ft-poller expects a url';
 			}
-			if ((response.headers.get('content-type') || '').indexOf('json') > -1) {
-				return response.json();
-			} else {
-				return response.text();
+
+			this.url = config.url;
+			this.options = config.options || {};
+			this.data = config.defaultData;
+			this.options.timeout = this.options.timeout || 4000;
+
+			this.options.headers = this.options.headers || {};
+
+			this._fetch = this.options.retry ? this.eagerFetch : fetch;
+
+			if (!this.options.headers['Content-Type']) {
+				this.options.headers['Content-Type'] = 'application/json';
 			}
-		})
-		.then(function(s) {
-			self.data = self.parseData(s);
-			self.emit('data', self.data);
-		})
-		.catch(function (err) {
-			self.emit('error', err);
-		});
+			if (!this.options.headers.Accept) {
+				this.options.headers['Accept'] = 'application/json';
+			}
+
+			this.refreshInterval = config.refreshInterval || 60000;
+			this.parseData = config.parseData || function (data) {
+					return data;
+				};
+			this.poller = undefined;
+			if (config.autostart) {
+				this.start({initialRequest: true})
+			}
+		}
+
+		isRunning(){
+			return !!this.poller;
+		}
+
+		stop(){
+			clearInterval(this.poller);
+			this.poller = undefined;
+			return true;
+		}
+
+		start(opts){
+			opts = opts || {};
+			let initialPromise;
+			if (!!this.isRunning()) {
+				throw new Error('Could not start job because the service is already running');
+			}
+
+			if (opts.initialRequest) {
+				initialPromise = this.fetch();
+			}
+
+			this.poller = setInterval( () => {
+				this.fetch();
+			}, this.refreshInterval);
+
+			return opts.initialRequest ? initialPromise : Promise.resolve();
+		}
+
+		retry(){
+			this.fetch();
+			clearInterval(this.poller);
+			this.poller = setInterval( () => {
+				this.fetch();
+			}, this.refreshInterval);
+		}
+
+		fetch(){
+			const time = new Date();
+			return this._fetch(this.url, this.options)
+				.then( (response) => {
+					const latency = new Date() - time;
+					if (response.status === 200) {
+						this.emit('ok', response, latency);
+					} else {
+						throw `Fetching ${response.url} failed with a ${response.status}, ${response.statusText}`;
+					}
+					if ((response.headers.get('content-type') || '').indexOf('json') > -1) {
+						return response.json();
+					} else {
+						return response.text();
+					}
+				})
+				.then((s) => {
+					this.data = this.parseData(s);
+					this.emit('data', this.data);
+				})
+				.catch( (err) => {
+					this.emit('error', err);
+				});
+		}
+
+		getData(){
+			return this.data;
+		}
+	}
 };
-
-Poller.prototype.getData = function () {
-	return this.data;
-}
-
-module.exports = Poller;

--- a/src/poller.js
+++ b/src/poller.js
@@ -65,8 +65,8 @@ Poller.prototype.start = function (opts) {
 Poller.prototype.retry = function(){
 	this.fetch();
 	clearInterval(this.poller);
-	this.poller = setInterval(function () {
-		self.fetch();
+	this.poller = setInterval( () => {
+		this.fetch();
 	}, this.refreshInterval);
 };
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,14 +1,10 @@
 'use strict';
+const util = require('util');
 
 var Poller = require('./poller');
 Poller.prototype.eagerFetch = require('n-eager-fetch');
 var EventEmitter = require('events').EventEmitter;
 
-var e = new EventEmitter();
-
-// mixin the EventEmitter methods to Poller, Eg. poller.on('ok', ...)
-Object.getOwnPropertyNames(EventEmitter.prototype).forEach(function (fn) {
-		Poller.prototype[fn] = e[fn];
-});
+util.inherits(Poller, EventEmitter);
 
 module.exports = Poller;

--- a/src/server.js
+++ b/src/server.js
@@ -1,10 +1,7 @@
 'use strict';
-const util = require('util');
+const EventEmitter = require('events').EventEmitter;
+const Poller = require('./poller')(EventEmitter);
 
-var Poller = require('./poller');
 Poller.prototype.eagerFetch = require('n-eager-fetch');
-var EventEmitter = require('events').EventEmitter;
-
-util.inherits(Poller, EventEmitter);
 
 module.exports = Poller;

--- a/tests/poller.spec.js
+++ b/tests/poller.spec.js
@@ -329,7 +329,6 @@ describe('Poller', function() {
 
 		const onSecond = data => {
 			try{
-				console.log('onSecond', data);
 				expect(data).to.deep.equal(stub1);
 				done();
 			}catch(e){


### PR DESCRIPTION
@wheresrhys 

The previous way of using EventEmitter means that an event on one poller is fired on all of them.

The correct way used to be using `util.inherits` but apparantly that doesn't work properly in node 4.

So I had to switch to ES6 classes.

This might be a major release, although there's no change to the API, or shall I just risk it?