### PR TITLE
Use data from previous successful fetch...

### DIFF
--- a/src/poller.js
+++ b/src/poller.js
@@ -110,10 +110,6 @@ module.exports = EventEmitter => {
 		}
 
 		getData () {
-			if (this.error) {
-				throw this.error;
-			}
-
 			return this.data;
 		}
 	};


### PR DESCRIPTION
...when the last fetch resulted in an error

One of the key features of ft-poller is that it keeps apps running
despite the occassional error. It will return the result from the last
successful fetch. Another feature is `defaultData` which allows the
application to start the poller with some default data in case the first
fetch fails or takes time to complete.

Applications using ft-poller seem to use both poller.data and poller.getData
and if they need to be aware of errors to do things like logging the
error (which often they don't) then they listen for them.

This reverts the change in the previous major version while keeping
the good parts of the fix (ie ensuring the EventEmitter always listens
for error events)