### PR TITLE
Add @financial-times/ft-dotcom team to CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # See https://help.github.com/articles/about-codeowners/ for more information about this file.
 
-* @financial-times/platforms
+* @financial-times/platforms @financial-times/ft-dotcom


### PR DESCRIPTION
While the FT.com Support team are doing work on the [Heroku log drains migration](https://financialtimes.atlassian.net/wiki/spaces/DS/pages/7883555001/Migrating+an+app+to+Heroku+log+drains), it makes sense for that team to take joint ownership (alongside the existing Platforms team owner) of this repo, which it transpires is one of the packages that needs upgrading as part of the migration.