### PR TITLE
Move mockery to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@financial-times/n-logger": "^10.3.0",
         "isomorphic-fetch": "^2.0.0",
-        "mockery": "^2.1.0",
         "n-eager-fetch": "^5.1.0"
       },
       "devDependencies": {
@@ -21,6 +20,7 @@
         "eslint": "^6.0.0",
         "lintspaces-cli": "^0.1.1",
         "mocha": "^2.3.3",
+        "mockery": "^2.1.0",
         "nock": "^2.13.0",
         "npm-prepublish": "^1.2.2",
         "sinon": "^1.10.3",
@@ -7534,7 +7534,8 @@
     "node_modules/mockery": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
-      "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA=="
+      "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA==",
+      "dev": true
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -18803,7 +18804,8 @@
     "mockery": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
-      "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA=="
+      "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "@financial-times/n-logger": "^10.3.0",
     "isomorphic-fetch": "^2.0.0",
-    "mockery": "^2.1.0",
     "n-eager-fetch": "^5.1.0"
   },
   "devDependencies": {
@@ -24,6 +23,7 @@
     "eslint": "^6.0.0",
     "lintspaces-cli": "^0.1.1",
     "mocha": "^2.3.3",
+    "mockery": "^2.1.0",
     "nock": "^2.13.0",
     "npm-prepublish": "^1.2.2",
     "sinon": "^1.10.3",


### PR DESCRIPTION
This is only used in the tests so we don't need to install it in production.