### PR TITLE
Support timeouts when using native fetch

### DIFF
--- a/src/poller.js
+++ b/src/poller.js
@@ -87,7 +87,14 @@ module.exports = EventEmitter => {
 			// later is discarded within pollers
 			const _fetch = this.options.retry ? this.eagerFetch : fetch;
 
-			return _fetch (this.url, this.options)
+			const options = {...this.options}
+			if (options.timeout) {
+				// add signal option to support native fetch, but keep timeout option
+				// too to support node-fetch@<2.3.0
+				options.signal = AbortSignal.timeout(options.timeout)
+			}
+
+			return _fetch (this.url, options)
 				.then ((response) => {
 					const latency = new Date () - time;
 					if (response.ok) {


### PR DESCRIPTION
`timeout` is a node-fetch [extension](https://github.com/node-fetch/node-fetch/tree/v2.7.0?tab=readme-ov-file#options) not present in the spec-compliant native fetch implementation. Use an `AbortSignal` (available in Node 18+, which is what we currently support) as an alternative so that both node-fetch and native fetch will time out as expected.

This is the only non-compliant code used directly in `ft-poller`, but callers of `ft-poller` could pass other extension options to the `Poller` constructor that we'll also have to look out for.