### PR TITLE
Check whether AbortSignal.timeout exists

### DIFF
--- a/src/poller.js
+++ b/src/poller.js
@@ -88,7 +88,11 @@ module.exports = EventEmitter => {
 			const _fetch = this.options.retry ? this.eagerFetch : fetch;
 
 			const options = {...this.options}
-			if (options.timeout) {
+			// FIXME: This is hideous, but we need to check whether AbortSignal.timeout is a function here.
+			// This is because lots of our apps use Jest + JSDom for testing which still doesn't have
+			// AbortSignal.timeout defined. There are plenty of places where poller isn't mocked in our
+			// tests and so I don't think we can avoid this check for now
+			if (options.timeout && AbortSignal.timeout) {
 				// add signal option to support native fetch, but keep timeout option
 				// too to support node-fetch@<2.3.0
 				options.signal = AbortSignal.timeout(options.timeout)


### PR DESCRIPTION
I hate this. Ivo and I chatted about it and I don't think there's a way around it for now while apps like [next-article use JSDom as a test environment in Jest](https://github.com/Financial-Times/next-article/blob/45abc6f4e7ceaa577797b388410434e2c7293064/jest.config.js#L2).