### PR TITLE
Replace isomorphic-fetch/node-fetch with undici (breaking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Where `config` is an object with the following properties
 
 * `url` [required]: Url to fetch data from
 * `defaultData` [recommended]: Data to return if the poller is yet to make a successful request. Typically this will be an empty object of the same type/structure as a successful response e.g. if a successful response would give you an array of users then set `defaultData: []`
-* `options` [optional]: options object to pass to isomorphic-fetch. If options is not defined or doesn't contain a `timeout` property, request timeout will be set to 4000ms by default. If `retry` is specified then n-eager-fetch is used to send the request instead of fetch
+* `options` [optional]: options object to pass to `fetch`. If options is not defined or doesn't contain a `signal` property, the request timeout will be set to 4000ms by default. If `retry` is specified then the fetch will be retried the given number of times before erroring
 * `refreshInterval` [default: 60000]: Number of milliseconds to wait between request for data
 * `autostart` [default: false]: Whether to start the poller automatically when the instance is created
 * `parseData` [optional]: function to post-process the data returned by the request. Should return the post-processed data e.g

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/logger": "^3.0.0",
-        "isomorphic-fetch": "^3.0.0",
-        "n-eager-fetch": "^8.0.0"
+        "undici": "^7.8.0"
       },
       "devDependencies": {
         "@dotcom-reliability-kit/eslint-config": "^3.0.0",
@@ -23,7 +22,6 @@
         "eslint": "^8.57.1",
         "mocha": "^11.1.0",
         "mockery": "^2.1.0",
-        "nock": "^13.5.6",
         "sinon": "^20.0.0"
       },
       "engines": {
@@ -1600,6 +1598,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -1609,6 +1608,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -2580,15 +2580,6 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "node_modules/isomorphic-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      }
-    },
     "node_modules/jest-diff": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
@@ -2726,12 +2717,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-      "dev": true
-    },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "node_modules/jsonparse": {
@@ -3306,18 +3291,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
-    "node_modules/n-eager-fetch": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/n-eager-fetch/-/n-eager-fetch-8.0.0.tgz",
-      "integrity": "sha512-wKdQtv/rkaDU0tURk4Zjs8KTi57PpSSZAvUC9G7qSsBa3dmiSk1q+XX7QJPijJxD8apOToEgNMNLXw5GdGk7cA==",
-      "dependencies": {
-        "isomorphic-fetch": "^3.0.0"
-      },
-      "engines": {
-        "node": "18.x || 20.x",
-        "npm": "7.x || 8.x || 9.x || 10.x"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3331,40 +3304,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/nock": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
-      "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.0",
-        "json-stringify-safe": "^5.0.1",
-        "propagate": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/node-gyp": {
@@ -4173,15 +4112,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/propagate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
-      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -4393,6 +4323,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "optional": true
     },
     "node_modules/secure-json-parse": {
@@ -4739,11 +4670,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "node_modules/triple-beam": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
@@ -4790,6 +4716,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.8.0.tgz",
+      "integrity": "sha512-vFv1GA99b7eKO1HG/4RPu2Is3FBTWBrmzqzO0mz+rLxN3yXkE4mqRcb8g8fHxzX4blEysrNZLqg5RbJLqX5buA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/unique-filename": {
@@ -4841,25 +4776,6 @@
       "dev": true,
       "dependencies": {
         "builtins": "^1.0.3"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -6322,6 +6238,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
       "optional": true,
       "requires": {
         "iconv-lite": "^0.6.2"
@@ -6331,6 +6248,7 @@
           "version": "0.6.3",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
           "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "dev": true,
           "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -7055,15 +6973,6 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "isomorphic-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-      "requires": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      }
-    },
     "jest-diff": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
@@ -7170,12 +7079,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-      "dev": true
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "jsonparse": {
@@ -7608,14 +7511,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
-    "n-eager-fetch": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/n-eager-fetch/-/n-eager-fetch-8.0.0.tgz",
-      "integrity": "sha512-wKdQtv/rkaDU0tURk4Zjs8KTi57PpSSZAvUC9G7qSsBa3dmiSk1q+XX7QJPijJxD8apOToEgNMNLXw5GdGk7cA==",
-      "requires": {
-        "isomorphic-fetch": "^3.0.0"
-      }
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -7627,25 +7522,6 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
       "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
       "dev": true
-    },
-    "nock": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
-      "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.1.0",
-        "json-stringify-safe": "^5.0.1",
-        "propagate": "^2.0.0"
-      }
-    },
-    "node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      }
     },
     "node-gyp": {
       "version": "8.4.1",
@@ -8267,12 +8143,6 @@
         "retry": "^0.12.0"
       }
     },
-    "propagate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
-      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
-      "dev": true
-    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -8405,6 +8275,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "optional": true
     },
     "secure-json-parse": {
@@ -8686,11 +8557,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "triple-beam": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
@@ -8723,6 +8589,11 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
+    },
+    "undici": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.8.0.tgz",
+      "integrity": "sha512-vFv1GA99b7eKO1HG/4RPu2Is3FBTWBrmzqzO0mz+rLxN3yXkE4mqRcb8g8fHxzX4blEysrNZLqg5RbJLqX5buA=="
     },
     "unique-filename": {
       "version": "1.1.1",
@@ -8773,25 +8644,6 @@
       "dev": true,
       "requires": {
         "builtins": "^1.0.3"
-      }
-    },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
   },
   "dependencies": {
     "@dotcom-reliability-kit/logger": "^3.0.0",
-    "isomorphic-fetch": "^3.0.0",
-    "n-eager-fetch": "^8.0.0"
+    "undici": "^7.8.0"
   },
   "devDependencies": {
     "@dotcom-reliability-kit/eslint-config": "^3.0.0",
@@ -26,7 +25,6 @@
     "eslint": "^8.57.1",
     "mocha": "^11.1.0",
     "mockery": "^2.1.0",
-    "nock": "^13.5.6",
     "sinon": "^20.0.0"
   },
   "scripts": {

--- a/src/eager-fetch.js
+++ b/src/eager-fetch.js
@@ -1,0 +1,38 @@
+// Copied from https://github.com/Financial-Times/n-eager-fetch/blob/main/main.js
+// now that n-eager-fetch is end-of-life
+'use strict';
+
+const { fetch } = require('undici');
+
+module.exports = function eagerFetch (url, opts) {
+	let retriesLeft = opts.retry;
+
+	// Not a valid fetch option so we remove it
+	delete opts.retry;
+
+	function fetchAttempt () {
+		const fetchCall = fetch(url, opts)
+			.catch( (err) => {
+				if (err.name === 'TimeoutError') {
+					return { ok: false };
+				} else {
+					throw err;
+				}
+			})
+			.then(function (response) {
+				if (!response.ok && retriesLeft > 0) {
+					retriesLeft--;
+					return fetchAttempt();
+				}
+				return response;
+			});
+
+		fetchCall.stopRetrying = function () {
+			retriesLeft = 0;
+		};
+
+		return fetchCall;
+	}
+
+	return fetchAttempt();
+};

--- a/src/poller.js
+++ b/src/poller.js
@@ -18,6 +18,14 @@ module.exports = EventEmitter => {
 			this.data = config.defaultData;
 			this.state = Poller.states.INITIAL;
 
+			if (this.options.timeout) {
+				logger.warn({
+					event: 'POLLER_DEPRECATED_OPTION',
+					message: 'The `timeout` option is deprecated, use the standard `signal` option instead',
+					option: 'timeout'
+				});
+			}
+
 			// HACK:20250430:RM: We check whether AbortSignal.timeout exists here as many
 			// of our apps use Jest + JSDom for testing which _still_ doesn't have
 			// AbortSignal.timeout defined. There are plenty of places where ft-poller

--- a/src/server.js
+++ b/src/server.js
@@ -3,6 +3,6 @@
 const EventEmitter = require ('events').EventEmitter;
 const Poller = require ('./poller')(EventEmitter);
 
-Poller.prototype.eagerFetch = require ('n-eager-fetch');
+Poller.prototype.eagerFetch = require('./eager-fetch');
 
 module.exports = Poller;


### PR DESCRIPTION
Since Node 18, Node has supported its own version of fetch (by re-exporting the undici project) so we no longer need to rely on node-fetch. Additionally, isomorphic-fetch has been causing issues for us as it installs node-fetch into the same global scope as Node's fetch would be accessed, but with an implementation of fetch that does not conform to web API specs.

We're making an effort to move away from isomorphic-fetch entirely, but a first step is to remove it from libraries that export isomorphic-fetch (and thus install node-fetch into the global scope.) Apps updating to this version of ft-poller should no longer expect isomorphic-fetch to be run (particularly if they have also updated n-express). As other libraries in our estate _may_ still be depending on having node-fetch in the global scope the safest course of action when migrating will be to import isomorphic-fetch explicitly in your own app. However, we recommend also trying with Node's fetch if feasible (this can be done by configuring Tool Kit to stop disabling Node's fetch) as this will make migrating to Node 24 easier in the future (and will also mean you're using more modern, standard tooling.) Mature projects such as cp-content-pipeline have already followed the latter route.

We've dropped n-eager-fetch in this commit, as that also was importing isomorphic-fetch but is an archived repository we no longer feel is worth maintaining, so we've instead copied the relevant code into this project.