### PR TITLE
Drop Node.js 18 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,6 @@ executors:
   node20_18:
     docker:
       - image: cimg/node:20.18
-  node18_20:
-    docker:
-      - image: cimg/node:18.20
 jobs:
   checkout:
     docker:
@@ -39,7 +36,6 @@ workflows:
               executor:
                 - node
                 - node20_18
-                - node18_20
           requires:
             - checkout
           filters:
@@ -52,7 +48,6 @@ workflows:
               executor:
                 - node
                 - node20_18
-                - node18_20
           requires:
             - tool-kit/setup-<< matrix.executor >>
           filters:
@@ -65,7 +60,6 @@ workflows:
               executor:
                 - node
                 - node20_18
-                - node18_20
           requires:
             - tool-kit/build-<< matrix.executor >>
           filters:
@@ -99,7 +93,6 @@ workflows:
               executor:
                 - node
                 - node20_18
-                - node18_20
           requires:
             - checkout
       - tool-kit/build:
@@ -109,7 +102,6 @@ workflows:
               executor:
                 - node
                 - node20_18
-                - node18_20
           requires:
             - tool-kit/setup-<< matrix.executor >>
       - tool-kit/test:
@@ -119,6 +111,5 @@ workflows:
               executor:
                 - node
                 - node20_18
-                - node18_20
           requires:
             - tool-kit/build-<< matrix.executor >>

--- a/.toolkitrc.yml
+++ b/.toolkitrc.yml
@@ -15,4 +15,3 @@ options:
       cimgNodeVersions:
         - '22.14'
         - '20.18'
-        - '18.20'

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "sinon": "^20.0.0"
       },
       "engines": {
-        "node": "18.x || 20.x || 22.x"
+        "node": "20.x || 22.x"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "start": "dotcom-tool-kit run:local"
   },
   "engines": {
-    "node": "18.x || 20.x || 22.x"
+    "node": "20.x || 22.x"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Node.js 18 is end of life now and we're about to release a breaking change with #212. I think it's worth avoiding a second breaking change soon after by batching these together.