### PR TITLE
build: set versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
 
   - package-ecosystem: "npm"
+    versioning-strategy: "increase"
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
This ensures that `package.json` is bumped instead of only `package-lock.json`.